### PR TITLE
Set API var to be relative to the current URL

### DIFF
--- a/app/scripts/api.js
+++ b/app/scripts/api.js
@@ -1,4 +1,6 @@
-var API = '/api/';
-//var API = '/';
+var API = (function() {
+    var m = window.location.pathname.match(/(.*\/)studio\/index.html/);
+    return m && m[1] ? m[1] : '/';
+})();
 
 var STUDIO_VERSION = "1.7";


### PR DESCRIPTION
This allows studio to be hosted on a different context path behind a reverse proxy. For example it is possible to use URLs like http://host/orient/studio/index.html
