### PR TITLE
Do not show in advance all the vertices linked by lightweight edges

### DIFF
--- a/app/scripts/widgets/orientdb-graphviz.js
+++ b/app/scripts/widgets/orientdb-graphviz.js
@@ -1683,8 +1683,7 @@ var OrientGraph = (function () {
                     if (self.isVertex(rid)) {
                       var v1 = self.get(rid);
                       if (!v1) {
-                        v1 = new OVertex(self, rid);
-                        self.addVertex(v1);
+                        return;
                       }
                       var cluster = rid.replace("#", "").split(":")[0];
                       var cfg = self.clusterClass[cluster];


### PR DESCRIPTION
The existing code draws all the vertices, connected by lightweight edges to those that are requested. This does not work well when there is a graph with a big number of links on some edges. For example, if GratefulDeadConcerts had lightweight edges, running this query would blow up the graph:

traverse in('written_by') from (select from V where name='Weir')

as Weir has about 100 edges of type 'sung_by'.

The images demonstrate the difference before and after the patch (the GratefulDeadConcerts does not uses the lightweight edges, so this example is only an illustration):

Before:
![big-graph](https://cloud.githubusercontent.com/assets/194390/8521564/849dd3c6-23ed-11e5-9292-f67e2f4a62c6.png)

After:
![small-graph](https://cloud.githubusercontent.com/assets/194390/8521583/d4720a66-23ed-11e5-926f-c1a5ada5c874.png)
