### PR TITLE
Solve Timepicker and angular parse errors

### DIFF
--- a/app/views/widget/datetime.html
+++ b/app/views/widget/datetime.html
@@ -9,7 +9,7 @@
             </i>
         </button>
     </span>
-    <input data-time-format="HH:mm" class="form-control" ng-required='isRequired(header)' orientdatetime bs-timepicker
+    <input data-time-format="HH:mm:ss" class="form-control" ng-required='isRequired(header)' orientdatetime bs-timepicker
            ng-model='doc[header]' type="text"/>
     <span class="input-group-btn">
         <button class="btn">


### PR DESCRIPTION
Bad format for the timepicker, Orientdb parses with seconds. Cannot add manually because angular marks with error adding the seconds.
NgStrap also supports this format.