### PR TITLE
Fixed a couple of small issues relating to the handling of backup log entries.

### DIFF
--- a/src/app/administration/stats/backup/singlebackup.component.html
+++ b/src/app/administration/stats/backup/singlebackup.component.html
@@ -85,6 +85,10 @@
                         </ul>
                     </div>
                     <div *ngIf="backup.uuid">
+                        <div *ngIf="totalFilteredLogs > maxCalendarEvents" class="alert alert-info" style="margin-bottom: 10px;">
+                            <i class="fa fa-info-circle"></i>
+                            Showing {{maxCalendarEvents}} most recent events out of {{totalFilteredLogs}} total events.
+                        </div>
                         <backup-calendar [events]="currentUnitLogs" (onRange)="changeRange($event)" (onSelected)="selectEvent($event)"></backup-calendar>
                     </div>
 

--- a/src/app/administration/stats/backup/singlebackup.component.ts
+++ b/src/app/administration/stats/backup/singlebackup.component.ts
@@ -85,6 +85,8 @@ class SingleBackupComponent implements OnInit, OnDestroy, OnChanges {
   private range: any;
   private logs = [];
   private currentUnitLogs = [];
+  private maxCalendarEvents = 1000; // Limit events shown in calendar for performance
+  private totalFilteredLogs = 0; // Track total logs before limiting
 
   constructor(
     private agent: AgentService,
@@ -214,7 +216,10 @@ class SingleBackupComponent implements OnInit, OnDestroy, OnChanges {
     } else {
       this.selectedEvents.splice(idx, 1);
     }
-    this.currentUnitLogs = formatLogs(this.logs, this.selectedEvents);
+    const result = formatLogs(this.logs, this.selectedEvents, this.maxCalendarEvents);
+    this.currentUnitLogs = result.events;
+    this.totalFilteredLogs = result.total;
+    console.log("Event click handled, updated logs " + this.currentUnitLogs + " and total count: " + this.totalFilteredLogs);
   }
   getClazz(t) {
     return (
@@ -228,17 +233,26 @@ class SingleBackupComponent implements OnInit, OnDestroy, OnChanges {
   fetchBackups(id, params) {
     this.backupService.logs(id, params).then(data => {
       this.logs = data.logs;
-      this.currentUnitLogs = formatLogs(data.logs, this.selectedEvents);
+      const result = formatLogs(data.logs, this.selectedEvents, this.maxCalendarEvents);
+      this.currentUnitLogs = result.events;
+      this.totalFilteredLogs = result.total;
     });
   }
 }
 
-function formatLogs(logs, selectedEvents) {
-  return logs
-    .filter(e => {
+function formatLogs(logs, selectedEvents, maxEvents) {
+  // Filter by selected event types
+  const filtered = logs.filter(e => {
       return selectedEvents.indexOf(e.op) != -1;
-    })
-    .map((e, idx, arr) => {
+  });
+  // Sort by timestamp descending (most recent first)
+  const sorted = filtered.sort((a, b) => {
+    return b.timestamp - a.timestamp;
+  });
+  // Limit the number of events for performance
+  const limited = maxEvents ? sorted.slice(0, maxEvents) : sorted;
+  // Map to calendar event format
+  const events = limited.map((e, idx) => {
       var date = new Date(e.timestamp);
       return {
         id: idx,
@@ -250,6 +264,10 @@ function formatLogs(logs, selectedEvents) {
         className: clazz(e)
       };
     });
+  return {
+    events: events,
+    total: filtered.length
+  };
 }
 
 function clazz(event) {

--- a/src/app/util/cron.component.ts
+++ b/src/app/util/cron.component.ts
@@ -27,8 +27,8 @@ export class CronComponent implements OnInit, OnChanges {
   private changed: EventEmitter<any> = new EventEmitter();
 
   ngOnChanges(changes: SimpleChanges) {
-    if (this.cronElement) {
-      this.cronElement.cron("value", changes.cron.currentValue);
+    if (this.cronElement && changes.cronVal) {
+      this.cronElement.cron("value", changes.cronVal.currentValue);
     }
   }
   ngOnInit(): void {


### PR DESCRIPTION
This pull request fixes the issue reported in issue #588 where opening the database backups view generates an error in the logs.

It also fixes issue #589 where too many backup log entries can overwhelm the client and slow down the entire studio app.
 
The fix for this issue involves adding a filter to limit the total number of entries that are loaded and displayed from the backup log to prevent a very large number of log entries from slowing down the entire studio app.

This is a quick fix. A better fix would involve caching the backup log events on the client so that they are not constantly reloaded. 